### PR TITLE
Fix test imports by adjusting Python path

### DIFF
--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -1,4 +1,10 @@
+import sys
+from pathlib import Path
+
 import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
 from app import app
 from models import Base, Video, VideoStatistic, Thumbnail, Caption
 from sqlalchemy import create_engine


### PR DESCRIPTION
## Summary
- add path adjustments in backend tests so Python can import `app`

## Testing
- `pytest -q` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6841982c4330832682acd7546ee2e8c1