### PR TITLE
Fix video duration stored as seconds

### DIFF
--- a/backend/youtube_service.py
+++ b/backend/youtube_service.py
@@ -206,7 +206,8 @@ class YouTubeService:
             video.description = snippet.get("description", "")
             video.channel_id = snippet.get("channelId")
             video.channel_title = snippet.get("channelTitle")
-            video.duration = parse_duration(content_details.get("duration", "PT0S"))
+            duration_td = parse_duration(content_details.get("duration", "PT0S"))
+            video.duration = int(duration_td.total_seconds())
             video.default_language = snippet.get("defaultAudioLanguage")
             video.category_id = int(snippet["categoryId"]) if snippet.get("categoryId") else None
             video.raw_snippet = snippet


### PR DESCRIPTION
## Summary
- parse the video duration with `isodate.parse_duration` and store seconds

## Testing
- `pytest` *(fails: connection to Postgres refused)*

------
https://chatgpt.com/codex/tasks/task_e_6841d0d4babc8326aadf2054c2fb557d