### PR TITLE
Add basic auth flow

### DIFF
--- a/src/app/auth/page.tsx
+++ b/src/app/auth/page.tsx
@@ -50,10 +50,29 @@ export default function AuthPage() {
     password: ''
   });
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    // TODO: Implement authentication logic
-    console.log('Form submitted:', formData);
+    const baseUrl = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:5000';
+    const endpoint = isLogin ? '/api/login' : '/api/signup';
+    try {
+      const res = await fetch(`${baseUrl}${endpoint}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(formData)
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.error || 'Request failed');
+      }
+
+      const data = await res.json();
+      console.log('Auth success:', data);
+      window.location.href = '/dashboard';
+    } catch (err) {
+      console.error('Auth error:', err);
+      alert('Authentication failed');
+    }
   };
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
## Summary
- implement simple login & signup endpoints on Flask backend
- allow CORS and store temporary users in memory
- add tests for new auth endpoints
- connect auth page in Next.js to backend API

## Testing
- `pip install -r requirements.txt`
- `pip install flask_cors`
- `pip install pgvector`
- `pytest -q` *(fails: OperationalError connecting to Postgres)*

------
https://chatgpt.com/codex/tasks/task_e_6841e25ee9b883268d45a9713e86da2b