### PR TITLE
Fix incorrect import causing runtime error

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React from 'react';
-import { SplitText } from '@/components/ReactBits/SplitText';
+import SplitText from '@/components/ReactBits/SplitText';
 import BlurText from '@/components/ReactBits/BlurText';
 import {
   LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip,


### PR DESCRIPTION
## Summary
- fix SplitText import on the dashboard page

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6841f24f5aec832698bbf1eab9abe1e7