### PR TITLE
Add sentiment metrics chart

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -4,17 +4,36 @@ import React from 'react';
 import SplitText from '@/components/ReactBits/SplitText';
 import BlurText from '@/components/ReactBits/BlurText';
 import {
-  LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip,
-  BarChart, Bar, PieChart, Pie, Cell, ResponsiveContainer,
-  ScatterChart, Scatter, ZAxis
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  BarChart,
+  Bar,
+  PieChart,
+  Pie,
+  Cell,
+  ResponsiveContainer,
+  ScatterChart,
+  Scatter,
+  ZAxis,
 } from 'recharts';
 import styles from './page.module.scss';
 
 // Mock data placeholders
 const mockTrend = Array.from({ length: 12 }, (_, i) => ({
-  date: `2024-${(i+1).toString().padStart(2,'0')}-01`,
-  sentiment: Math.random() * 2 - 1,
-  mentions: Math.floor(Math.random()*100)+20,
+  date: `2024-${(i + 1).toString().padStart(2, '0')}-01`,
+  sentiment: parseFloat((Math.random() * 2 - 1).toFixed(2)),
+  combinedScore: parseFloat((Math.random() * 2 - 1).toFixed(2)),
+  valence: parseFloat((Math.random() * 2 - 1).toFixed(2)),
+  continuousScore: parseFloat((Math.random() * 2 - 1).toFixed(2)),
+  signedValue: parseFloat((Math.random() * 2 - 1).toFixed(2)),
+  score: parseFloat((Math.random() * 2 - 1).toFixed(2)),
+  expSent: parseFloat((Math.random() * 2 - 1).toFixed(2)),
+  mentions: Math.floor(Math.random() * 100) + 20,
 }));
 
 const mockDistribution = [
@@ -63,14 +82,21 @@ export default function DashboardPage() {
       {/* Trend & Distribution */}
       <section className={styles.chartsRow}>
         <div className={styles.chartCard}>
-          <h2>Sentiment Trend</h2>
+          <h2>Sentiment Metrics Trend</h2>
           <ResponsiveContainer width="100%" height={250}>
             <LineChart data={mockTrend}>
               <CartesianGrid strokeDasharray="3 3" />
               <XAxis dataKey="date" />
-              <YAxis domain={[-1,1]} />
+              <YAxis domain={[-1, 1]} />
               <Tooltip />
+              <Legend />
               <Line type="monotone" dataKey="sentiment" stroke="#00695C" />
+              <Line type="monotone" dataKey="combinedScore" stroke="#B8860B" />
+              <Line type="monotone" dataKey="valence" stroke="#B71C1C" />
+              <Line type="monotone" dataKey="continuousScore" stroke="#B2DFDB" />
+              <Line type="monotone" dataKey="signedValue" stroke="#CFD8DC" />
+              <Line type="monotone" dataKey="score" stroke="#F8BBD0" />
+              <Line type="monotone" dataKey="expSent" stroke="#512DA8" />
             </LineChart>
           </ResponsiveContainer>
         </div>

--- a/src/components/ReactBits/BlurText.tsx
+++ b/src/components/ReactBits/BlurText.tsx
@@ -1,7 +1,7 @@
 import { useRef, useEffect, useState } from 'react';
 import { useSprings, animated } from '@react-spring/web';
 
-interface SplitTextProps {
+interface BlurTextProps {
   text?: string;
   className?: string;
   delay?: number;
@@ -27,7 +27,7 @@ const BlurText = ({
   animationTo,
   easing = 'easeOutCubic',
   onAnimationComplete,
-}) => {
+}: BlurTextProps) => {
   const elements: string[] = animateBy === 'words' ? text.split(' ') : text.split('');
   const [inView, setInView] = useState(false);
   const ref = useRef<HTMLParagraphElement>(null);

--- a/src/components/ReactBits/SplitText.tsx
+++ b/src/components/ReactBits/SplitText.tsx
@@ -1,4 +1,4 @@
-import { useSprings, animated, SpringValue, animated as a } from '@react-spring/web';
+import { useSprings, animated as a } from '@react-spring/web';
 import { useEffect, useRef, useState } from 'react';
 
 interface SplitTextProps {
@@ -7,17 +7,10 @@ interface SplitTextProps {
   delay?: number;
   animationFrom?: { opacity: number; transform: string };
   animationTo?: { opacity: number; transform: string };
-  easing?: string;
   threshold?: number;
   rootMargin?: string;
   textAlign?: 'left' | 'center' | 'right';
   onLetterAnimationComplete?: () => void;
-}
-
-// Define a type for the spring values
-interface SpringProps {
-  opacity: SpringValue<number>;
-  transform: SpringValue<string>;
 }
 
 const AnimatedLetter = a('span');
@@ -28,7 +21,6 @@ const SplitText = ({
   delay = 100,
   animationFrom = { opacity: 0, transform: 'translate3d(0,40px,0)' },
   animationTo = { opacity: 1, transform: 'translate3d(0,0,0)' },
-  easing = 'easeOutCubic',
   threshold = 0.1,
   rootMargin = '-100px',
   textAlign = 'center',


### PR DESCRIPTION
## Summary
- expand mock data to include multiple sentiment metrics
- show a multi-line chart for the metrics
- fix lint errors in BlurText and SplitText components

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6841f45b9a2c8326921b6f0dc23a5f2d