### PR TITLE
Implement persistent login and sidebar

### DIFF
--- a/src/app/auth/page.tsx
+++ b/src/app/auth/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState } from 'react';
+import { useAuth } from '@/context/AuthContext';
 import { FiMail, FiLock } from 'react-icons/fi';
 import { 
   FaMicrosoft, 
@@ -49,29 +50,20 @@ export default function AuthPage() {
     email: '',
     password: ''
   });
+  const { login, signup } = useAuth();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    const baseUrl = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:5000';
-    const endpoint = isLogin ? '/api/login' : '/api/signup';
     try {
-      const res = await fetch(`${baseUrl}${endpoint}`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(formData)
-      });
-
-      if (!res.ok) {
-        const data = await res.json();
-        throw new Error(data.error || 'Request failed');
+      if (isLogin) {
+        await login(formData.email, formData.password);
+      } else {
+        await signup(formData.name, formData.email, formData.password);
       }
-
-      const data = await res.json();
-      console.log('Auth success:', data);
       window.location.href = '/dashboard';
     } catch (err) {
-      console.error('Auth error:', err);
-      alert('Authentication failed');
+      const message = err instanceof Error ? err.message : 'Authentication failed';
+      alert(message);
     }
   };
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Layout } from '@/components/Layout/Layout';
+import { AuthProvider } from '@/context/AuthContext';
 import '@/styles/global.scss';
 
 export const metadata = {
@@ -11,7 +12,9 @@ export const metadata = {
 // Client-side wrapper component
 const ClientLayout = ({ children }: { children: React.ReactNode }) => {
   return (
-    <Layout>{children}</Layout>
+    <AuthProvider>
+      <Layout>{children}</Layout>
+    </AuthProvider>
   );
 };
 

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -5,6 +5,7 @@ import { usePathname } from 'next/navigation';
 import Header from './Header';
 import Footer from './Footer';
 import Sidebar from './Sidebar';
+import { useAuth } from '@/context/AuthContext';
 import styles from './Layout.module.scss';
 
 interface LayoutProps {
@@ -13,9 +14,10 @@ interface LayoutProps {
 
 export const Layout: React.FC<LayoutProps> = ({ children }) => {
   const pathname = usePathname();
-  
-  // Show sidebar on data-driven pages
-  const showSidebar = [
+  const { user } = useAuth();
+
+  // Show sidebar when logged in or on data-driven pages
+  const showSidebar = user || [
     '/entity',
     '/video',
     '/explore',
@@ -24,7 +26,7 @@ export const Layout: React.FC<LayoutProps> = ({ children }) => {
 
   return (
     <div className={styles.layout}>
-      <Header />
+      {!user && <Header />}
       <div className={styles.main}>
         {showSidebar && <Sidebar />}
         <main className={styles.content}>

--- a/src/components/Layout/Sidebar.module.scss
+++ b/src/components/Layout/Sidebar.module.scss
@@ -25,6 +25,13 @@
   gap: var(--spacing-sm);
 }
 
+.userSection {
+  margin-top: auto;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+}
+
 
 .navItem {
   display: flex;
@@ -35,6 +42,10 @@
   border-radius: var(--radius-sm);
   transition: background-color var(--transition-fast);
   white-space: nowrap;
+  background: none;
+  border: none;
+  text-decoration: none;
+  cursor: pointer;
 
   &:hover {
     background-color: var(--primary-dark);

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -2,11 +2,13 @@ import React from 'react';
 import Link from 'next/link';
 import * as Collapsible from '@radix-ui/react-collapsible';
 import { ChevronLeftIcon, ChevronRightIcon } from '@radix-ui/react-icons';
-import { FaHome, FaChartLine, FaTachometerAlt } from 'react-icons/fa';
+import { FaHome, FaChartLine, FaTachometerAlt, FaUserCog, FaSignOutAlt, FaDollarSign } from 'react-icons/fa';
+import { useAuth } from '@/context/AuthContext';
 import styles from './Sidebar.module.scss';
 
 export const Sidebar: React.FC = () => {
   const [isOpen, setIsOpen] = React.useState(true);
+  const { user, logout } = useAuth();
 
   return (
     <Collapsible.Root
@@ -31,6 +33,23 @@ export const Sidebar: React.FC = () => {
           {/* TODO: Add contextual filters based on page view */}
           {/* TODO: Add "Saved Searches" for logged-in users */}
         </nav>
+
+        {user && (
+          <div className={styles.userSection}>
+            <Link href="/settings" className={styles.navItem}>
+              <FaUserCog className={styles.icon} />
+              {isOpen && <span>Settings</span>}
+            </Link>
+            <Link href="/pricing" className={styles.navItem}>
+              <FaDollarSign className={styles.icon} />
+              {isOpen && <span>Pricing</span>}
+            </Link>
+            <button onClick={logout} className={styles.navItem}>
+              <FaSignOutAlt className={styles.icon} />
+              {isOpen && <span>Sign Out</span>}
+            </button>
+          </div>
+        )}
 
         <Collapsible.Trigger asChild>
           <button className={styles.trigger}>

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -1,0 +1,87 @@
+"use client";
+import React, { createContext, useContext, useEffect, useState, ReactNode } from "react";
+
+interface User {
+  email: string;
+  name?: string;
+  token: string;
+}
+
+interface AuthContextProps {
+  user: User | null;
+  login: (email: string, password: string) => Promise<void>;
+  signup: (name: string, email: string, password: string) => Promise<void>;
+  logout: () => void;
+}
+
+const noop = async () => {};
+
+export const AuthContext = createContext<AuthContextProps>({
+  user: null,
+  login: noop,
+  signup: noop,
+  logout: () => {}
+});
+
+export const useAuth = () => useContext(AuthContext);
+
+export const AuthProvider = ({ children }: { children: ReactNode }) => {
+  const [user, setUser] = useState<User | null>(null);
+
+  useEffect(() => {
+    const stored = localStorage.getItem("user");
+    if (stored) {
+      try {
+        setUser(JSON.parse(stored));
+      } catch {
+        localStorage.removeItem("user");
+      }
+    }
+  }, []);
+
+  const baseUrl = process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:5000";
+
+  const login = async (email: string, password: string) => {
+    const res = await fetch(`${baseUrl}/api/login`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email, password })
+    });
+
+    if (!res.ok) {
+      const data = await res.json();
+      throw new Error(data.error || "Login failed");
+    }
+
+    const data = await res.json();
+    const newUser = { email, token: data.token } as User;
+    setUser(newUser);
+    localStorage.setItem("user", JSON.stringify(newUser));
+  };
+
+  const signup = async (name: string, email: string, password: string) => {
+    const res = await fetch(`${baseUrl}/api/signup`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name, email, password })
+    });
+
+    if (!res.ok) {
+      const data = await res.json();
+      throw new Error(data.error || "Signup failed");
+    }
+
+    await login(email, password);
+  };
+
+  const logout = () => {
+    localStorage.removeItem("user");
+    setUser(null);
+  };
+
+  return (
+    <AuthContext.Provider value={{ user, login, signup, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};


### PR DESCRIPTION
## Summary
- add context-based auth provider for tracking user tokens
- wrap the application with `AuthProvider`
- hide the header when a user is logged in and always show sidebar
- extend sidebar with user section for settings, pricing and sign out
- use the new context in the auth page and remove console logs

## Testing
- `npm run lint` *(fails: SplitText component lint errors)*
- `pytest -q backend/tests` *(fails: database connection error)*

------
https://chatgpt.com/codex/tasks/task_e_6841f5ff30048326a0a7f0031a6d8e1e