### PR TITLE
Implement dynamic dashboard

### DIFF
--- a/src/app/dashboard/page.module.scss
+++ b/src/app/dashboard/page.module.scss
@@ -74,3 +74,60 @@
     margin-right: $spacing-xs;
   }
 }
+
+.queryControls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: $spacing-md;
+  margin-bottom: $spacing-lg;
+
+  input {
+    padding: $spacing-xs $spacing-sm;
+    border: 1px solid $color-border;
+    border-radius: $radius-sm;
+    font: inherit;
+  }
+
+  button {
+    background: $color-primary;
+    color: $color-text-light;
+    border: none;
+    padding: $spacing-xs $spacing-sm;
+    border-radius: $radius-sm;
+    cursor: pointer;
+  }
+}
+
+.queryList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: $spacing-sm;
+  margin-bottom: $spacing-lg;
+
+  .queryItem {
+    display: flex;
+    align-items: center;
+    padding: 2px $spacing-xs;
+    border-radius: $radius-sm;
+    color: $color-text-light;
+
+    button {
+      background: none;
+      border: none;
+      color: inherit;
+      cursor: pointer;
+      margin-left: $spacing-xs;
+    }
+  }
+}
+
+.toggleControls {
+  margin-bottom: $spacing-xl;
+
+  label {
+    margin-right: $spacing-md;
+    display: inline-flex;
+    align-items: center;
+    gap: $spacing-xs;
+  }
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React from 'react';
+import React, { useState } from 'react';
 import SplitText from '@/components/ReactBits/SplitText';
 import BlurText from '@/components/ReactBits/BlurText';
 import {
@@ -13,9 +13,6 @@ import {
   Legend,
   BarChart,
   Bar,
-  PieChart,
-  Pie,
-  Cell,
   ResponsiveContainer,
   ScatterChart,
   Scatter,
@@ -23,24 +20,36 @@ import {
 } from 'recharts';
 import styles from './page.module.scss';
 
-// Mock data placeholders
-const mockTrend = Array.from({ length: 12 }, (_, i) => ({
-  date: `2024-${(i + 1).toString().padStart(2, '0')}-01`,
-  sentiment: parseFloat((Math.random() * 2 - 1).toFixed(2)),
-  combinedScore: parseFloat((Math.random() * 2 - 1).toFixed(2)),
-  valence: parseFloat((Math.random() * 2 - 1).toFixed(2)),
-  continuousScore: parseFloat((Math.random() * 2 - 1).toFixed(2)),
-  signedValue: parseFloat((Math.random() * 2 - 1).toFixed(2)),
-  score: parseFloat((Math.random() * 2 - 1).toFixed(2)),
-  expSent: parseFloat((Math.random() * 2 - 1).toFixed(2)),
-  mentions: Math.floor(Math.random() * 100) + 20,
-}));
+const months = Array.from({ length: 12 }, (_, i) =>
+  `2024-${(i + 1).toString().padStart(2, '0')}-01`
+);
 
-const mockDistribution = [
-  { name: 'Positive', value: 45, color: '#B2DFDB' },
-  { name: 'Neutral', value: 35, color: '#CFD8DC' },
-  { name: 'Negative', value: 20, color: '#F8BBD0' },
+interface QueryPoint {
+  date: string;
+  value: number;
+}
+
+interface Query {
+  id: number;
+  term: string;
+  color: string;
+  data: QueryPoint[];
+}
+
+const generateQueryData = (): QueryPoint[] =>
+  months.map((date) => ({ date, value: parseFloat((Math.random() * 2 - 1).toFixed(2)) }));
+
+const queryColors = [
+  '#00695C',
+  '#B8860B',
+  '#B71C1C',
+  '#512DA8',
+  '#F8BBD0',
+  '#B2DFDB',
 ];
+
+// Static mock data for optional panels
+
 
 const mockTopEntities = [
   { name: 'OpenAI', count: 120 },
@@ -69,6 +78,39 @@ const mockSnippets = Array.from({ length: 3 }, (_, i) => ({
 }));
 
 export default function DashboardPage() {
+  const [queries, setQueries] = useState<Query[]>([]);
+  const [nextId, setNextId] = useState(1);
+  const [inputTerm, setInputTerm] = useState('');
+  const [showTopEntities, setShowTopEntities] = useState(true);
+  const [showComparison, setShowComparison] = useState(true);
+  const [showVAD, setShowVAD] = useState(true);
+
+  const addQuery = () => {
+    if (!inputTerm.trim()) return;
+    setQueries((qs) => [
+      ...qs,
+      {
+        id: nextId,
+        term: inputTerm.trim(),
+        color: queryColors[(nextId - 1) % queryColors.length],
+        data: generateQueryData(),
+      },
+    ]);
+    setNextId((id) => id + 1);
+    setInputTerm('');
+  };
+
+  const removeQuery = (id: number) =>
+    setQueries((qs) => qs.filter((q) => q.id !== id));
+
+  const chartData = months.map((date, idx) => {
+    const obj: Record<string, number | string> = { date };
+    queries.forEach((q) => {
+      obj[q.term] = q.data[idx].value;
+    });
+    return obj;
+  });
+
   return (
     <main className={styles.dashboardPage}>
       <header className={styles.header}>
@@ -79,95 +121,140 @@ export default function DashboardPage() {
         />
       </header>
 
-      {/* Trend & Distribution */}
-      <section className={styles.chartsRow}>
-        <div className={styles.chartCard}>
-          <h2>Sentiment Metrics Trend</h2>
-          <ResponsiveContainer width="100%" height={250}>
-            <LineChart data={mockTrend}>
-              <CartesianGrid strokeDasharray="3 3" />
-              <XAxis dataKey="date" />
-              <YAxis domain={[-1, 1]} />
-              <Tooltip />
-              <Legend />
-              <Line type="monotone" dataKey="sentiment" stroke="#00695C" />
-              <Line type="monotone" dataKey="combinedScore" stroke="#B8860B" />
-              <Line type="monotone" dataKey="valence" stroke="#B71C1C" />
-              <Line type="monotone" dataKey="continuousScore" stroke="#B2DFDB" />
-              <Line type="monotone" dataKey="signedValue" stroke="#CFD8DC" />
-              <Line type="monotone" dataKey="score" stroke="#F8BBD0" />
-              <Line type="monotone" dataKey="expSent" stroke="#512DA8" />
-            </LineChart>
-          </ResponsiveContainer>
-        </div>
-        <div className={styles.chartCard}>
-          <h2>Overall Sentiment</h2>
-          <ResponsiveContainer width="100%" height={250}>
-            <PieChart>
-              <Pie data={mockDistribution} dataKey="value" nameKey="name" cx="50%" cy="50%" outerRadius={80}>
-                {mockDistribution.map((entry, i) => (
-                  <Cell key={`cell-${i}`} fill={entry.color} />
-                ))}
-              </Pie>
-              <Tooltip />
-            </PieChart>
-          </ResponsiveContainer>
-        </div>
-      </section>
+      <div className={styles.queryControls}>
+        <input
+          type="text"
+          value={inputTerm}
+          onChange={(e) => setInputTerm(e.target.value)}
+          placeholder="Add term or channel"
+        />
+        <button type="button" onClick={addQuery}>Add</button>
+      </div>
+      <div className={styles.queryList}>
+        {queries.map((q) => (
+          <span
+            key={q.id}
+            className={styles.queryItem}
+            style={{ backgroundColor: q.color }}
+          >
+            {q.term}
+            <button onClick={() => removeQuery(q.id)} aria-label="Remove">
+              &times;
+            </button>
+          </span>
+        ))}
+      </div>
 
-      {/* Top Entities */}
       <section className={styles.fullRow}>
-        <h2>Top Entities</h2>
+        <h2>Term Trend Comparison</h2>
         <ResponsiveContainer width="100%" height={300}>
-          <BarChart data={mockTopEntities}>
+          <LineChart data={chartData}>
             <CartesianGrid strokeDasharray="3 3" />
-            <XAxis dataKey="name" />
-            <YAxis />
+            <XAxis dataKey="date" />
+            <YAxis domain={[-1, 1]} />
             <Tooltip />
-            <Bar dataKey="count" fill="#B8860B" />
-          </BarChart>
-        </ResponsiveContainer>
-      </section>
-
-      {/* Entity Comparison */}
-      <section className={styles.fullRow}>
-        <h2>Channel Comparison</h2>
-        <ResponsiveContainer width="100%" height={300}>
-          <ScatterChart>
-            <CartesianGrid strokeDasharray="3 3" />
-            <XAxis dataKey="mentions" name="Mentions" />
-            <YAxis dataKey="sentiment" name="Sentiment" domain={[-1,1]} />
-            <ZAxis range={[100]} />
-            <Tooltip cursor={{ strokeDasharray: '3 3' }} />
-            <Scatter data={mockComparison} fill="#00695C" />
-          </ScatterChart>
-        </ResponsiveContainer>
-      </section>
-
-      {/* VAD Heatmap */}
-      <section className={styles.chartsRow}>
-        <div className={styles.chartCard}>
-          <h2>VAD Snapshot</h2>
-          <div className={styles.heatmap}>
-            {mockVAD.map(v => (
-              <div key={v.emotion} className={styles.heatCell} style={{opacity: v.value}}>
-                {v.emotion}
-              </div>
+            <Legend />
+            {queries.map((q) => (
+              <Line
+                key={q.id}
+                type="monotone"
+                dataKey={q.term}
+                stroke={q.color}
+              />
             ))}
+          </LineChart>
+        </ResponsiveContainer>
+      </section>
+
+      <div className={styles.toggleControls}>
+        <label>
+          <input
+            type="checkbox"
+            checked={showTopEntities}
+            onChange={(e) => setShowTopEntities(e.target.checked)}
+          />
+          Top Entities
+        </label>
+        <label>
+          <input
+            type="checkbox"
+            checked={showComparison}
+            onChange={(e) => setShowComparison(e.target.checked)}
+          />
+          Channel Comparison
+        </label>
+        <label>
+          <input
+            type="checkbox"
+            checked={showVAD}
+            onChange={(e) => setShowVAD(e.target.checked)}
+          />
+          Sentiment Details
+        </label>
+      </div>
+
+      {showTopEntities && (
+        <section className={styles.fullRow}>
+          <h2>Top Entities</h2>
+          <ResponsiveContainer width="100%" height={300}>
+            <BarChart data={mockTopEntities}>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis dataKey="name" />
+              <YAxis />
+              <Tooltip />
+              <Bar dataKey="count" fill="#B8860B" />
+            </BarChart>
+          </ResponsiveContainer>
+        </section>
+      )}
+
+      {showComparison && (
+        <section className={styles.fullRow}>
+          <h2>Channel Comparison</h2>
+          <ResponsiveContainer width="100%" height={300}>
+            <ScatterChart>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis dataKey="mentions" name="Mentions" />
+              <YAxis dataKey="sentiment" name="Sentiment" domain={[-1, 1]} />
+              <ZAxis range={[100]} />
+              <Tooltip cursor={{ strokeDasharray: '3 3' }} />
+              <Scatter data={mockComparison} fill="#00695C" />
+            </ScatterChart>
+          </ResponsiveContainer>
+        </section>
+      )}
+
+      {showVAD && (
+        <section className={styles.chartsRow}>
+          <div className={styles.chartCard}>
+            <h2>VAD Snapshot</h2>
+            <div className={styles.heatmap}>
+              {mockVAD.map((v) => (
+                <div
+                  key={v.emotion}
+                  className={styles.heatCell}
+                  style={{ opacity: v.value }}
+                >
+                  {v.emotion}
+                </div>
+              ))}
+            </div>
           </div>
-        </div>
-        <div className={styles.chartCard}>
-          <h2>Contextual Snippets</h2>
-          <ul className={styles.snippetList}>
-            {mockSnippets.map(s => (
-              <li key={s.id}>
-                <span className={styles.time}>{Math.floor(s.timestamp/60)}:{String(s.timestamp%60).padStart(2,'0')}</span>
-                {s.text} <a href="#">({s.video})</a>
-              </li>
-            ))}
-          </ul>
-        </div>
-      </section>
+          <div className={styles.chartCard}>
+            <h2>Contextual Snippets</h2>
+            <ul className={styles.snippetList}>
+              {mockSnippets.map((s) => (
+                <li key={s.id}>
+                  <span className={styles.time}>
+                    {Math.floor(s.timestamp / 60)}:{String(s.timestamp % 60).padStart(2, '0')}
+                  </span>
+                  {s.text} <a href="#">({s.video})</a>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </section>
+      )}
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- add new query controls and trend comparison line chart
- allow toggling of top entities, channel comparison, and sentiment panels
- clean up unused chart imports
- style additions for query and toggle controls

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841f6fccff48326980136ac652dd65a